### PR TITLE
Fix eslint configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,7 +22,6 @@ export default tseslint.config(
       ...angular.configs.tsRecommended      
     ],
     linterOptions: {
-      noInlineConfig: true,
       reportUnusedDisableDirectives: true,
     },
     languageOptions: {
@@ -60,14 +59,13 @@ export default tseslint.config(
         "error",
         { "assertionStyle": "never" }
       ],
-      "@typescript-eslint/consistent-type-imports": "error",
       "@typescript-eslint/explicit-function-return-type": "error",
       "@typescript-eslint/explicit-member-accessibility": [
         "error",
         { "accessibility": "explicit", "overrides": { "constructors": "off" } }
       ],
       "@typescript-eslint/member-ordering": "error",
-      "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+      "@typescript-eslint/consistent-type-definitions": ["error"],
       "@typescript-eslint/await-thenable": "error",
       "unicorn/better-regex": "error",
       "unicorn/no-array-callback-reference": "off",

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,4 +3,4 @@ import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 
 bootstrapApplication(AppComponent, appConfig)
-  .catch((err) => console.error(err));
+  .catch((err) => console.error(err)); // eslint-disable-line no-console


### PR DESCRIPTION
## Fix eslint configuration

- [x] 🐛 fix: eslint config

### Description

#### **Delete some rules:**
- @typescript-eslint/consistent-type-imports: error
- noInlineConfig: true

#### **Fix config for rule "consistent-type-definitions":**
- "interface" is the default