### PR TITLE
feat: add guard for auth routing

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { MainPageComponent } from './pages/main-page/main-page.component';
 import { NotFoundPageComponent } from './pages/not-found-page/not-found-page.component';
 import { CatalogProductPageComponent } from './pages/catalog-product-page/catalog-product-page.component';
 import { AboutUsPageComponent } from './pages/about-us-page/about-us-page.component';
+import { noAuthGuard } from './guards/no-auth.guard';
 
 export const routes: Routes = [
   {
@@ -13,8 +14,16 @@ export const routes: Routes = [
     component: LayoutComponent,
     children: [
       { path: '', component: MainPageComponent },
-      { path: 'login', component: LoginPageComponent },
-      { path: 'registration', component: RegistrationPageComponent },
+      {
+        path: 'login',
+        component: LoginPageComponent,
+        canActivate: [noAuthGuard],
+      },
+      {
+        path: 'registration',
+        component: RegistrationPageComponent,
+        canActivate: [noAuthGuard],
+      },
       { path: 'catalog', component: CatalogProductPageComponent },
       { path: 'about', component: AboutUsPageComponent },
       { path: '**', component: NotFoundPageComponent },

--- a/src/app/guards/no-auth.guard.spec.ts
+++ b/src/app/guards/no-auth.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { noAuthGuard } from './no-auth.guard';
+
+describe('noAuthGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) =>
+    TestBed.runInInjectionContext(() => noAuthGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/guards/no-auth.guard.ts
+++ b/src/app/guards/no-auth.guard.ts
@@ -1,0 +1,12 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../auth/auth.service';
+import { inject } from '@angular/core';
+
+export const noAuthGuard: CanActivateFn = () => {
+  const isAuth = inject(AuthService).isAuth;
+
+  if (!isAuth) {
+    return true;
+  }
+  return inject(Router).createUrlTree(['']);
+};

--- a/src/app/pages/main-page/main-page.component.css
+++ b/src/app/pages/main-page/main-page.component.css
@@ -3,6 +3,6 @@
   -webkit-text-fill-color: transparent;
   @media (max-width: 1050px) {
     font-weight: 800;
-    -webkit-text-fill-color: #524139FF;
+    -webkit-text-fill-color: #524139ff;
   }
 }

--- a/src/app/pages/registration-page/registration-page.component.css
+++ b/src/app/pages/registration-page/registration-page.component.css
@@ -1,5 +1,5 @@
-input[type="number"]::-webkit-inner-spin-button, 
-input[type="number"]::-webkit-outer-spin-button { 
-  -webkit-appearance: none; 
-  margin: 0; 
+input[type='number']::-webkit-inner-spin-button,
+input[type='number']::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }


### PR DESCRIPTION
## Pull Request

### This is a ...

- [x] 🌟 feat: add guard for auth routing


#### Description

- **Date Done:** 18.05.2025 / 20.05.2025

- **Link task:** [RSS-ECOMM-2_06](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint2/RSS-ECOMM-2_06.md)

- **Brief Overview:**
A guard was written to protect the login and registration page from being accessed by authorized users

#### Additional Information

#### Checklist of completed tasks / Implemented features

- [x] Authenticated users who attempt to visit the login page are automatically redirected to the main page.
- [x] The URL in the address bar is changed to the main page's URL for authenticated users redirected from the login page.
- [x] Redirection maintains the user's authentication state during the process.
