### PR TITLE
refactor: delete 'e.g' for error email

### DIFF
--- a/src/app/pages/login-page/login-page.component.html
+++ b/src/app/pages/login-page/login-page.component.html
@@ -25,7 +25,7 @@
           >Please, delete spaces.</mat-error
         >
         <mat-error *ngIf="loginForm.get('email')?.errors?.['domain']"
-          >Email address must contain a domain name (e.g., example.com).</mat-error
+          >Email address must contain a domain name.</mat-error
         >
         <mat-error *ngIf="loginForm.get('email')?.errors?.['dog']"
           >Email address must contain an '&#64;' symbol.


### PR DESCRIPTION
## Pull Request

### This is a ...

- [x] 🌐 Other

#### Description

- **Date Done:** 19.05.2025 / 20.05.2025

- **Brief Overview:**
  📖 fixed the display of mail validation errors on the login page

#### Additional Information

- **Screenshots(if you need it):**
![image](https://github.com/user-attachments/assets/4be37441-7f35-4cf9-a392-c1cfff528ba4)

#### Checklist of completed tasks / Implemented features

- [x] delete 'e.g' for error email
